### PR TITLE
Including /sites next to /teams root

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Create an Azure AD app to Query the Message Center API.
     ![Update Variables](https://github.com/ericsche/MCinTeams/blob/main/Screenshots/Picture37.png)
 
     > **Note:** **TenantID, ClientID & AppSecrets** are values you saved from the [Create the Azure AD App Id](#create-the-azure-ad-app-id) section.
-    > **SharepointSiteURL** should be the base URL of the SharePoint Site backing up the team you hosted the solution in. It should look like ```https://TENANT NAME.sharepoint.com/teams/TEAM NAME/```.
+    > **SharepointSiteURL** should be the base URL of the SharePoint Site backing up the team you hosted the solution in. It should look like ```https://TENANT NAME.sharepoint.com/teams/TEAM NAME/``` or ```https://TENANT NAME.sharepoint.com/sites/TEAM NAME/```.
     > **ListName should** be the full name of the list you created in the [Create the Microsoft List in the team of your choosing](#create-the-microsoft-list-in-the-team-of-your-choosing) section.
 
 ### Configure the **Get New MC** flow


### PR DESCRIPTION
The root site for Team sites could also be /sites instead of /teams. Would be great to have that clarified in the Readme.